### PR TITLE
:wrench: moved documentation from .env file to vitepress

### DIFF
--- a/docs/stacks/synology-acme-dns.md
+++ b/docs/stacks/synology-acme-dns.md
@@ -20,10 +20,75 @@ You **do not need to open any ports on your firewall / router**, you can issue w
 
 Before using this stack, adjust:
 
-- **DNS API Credentials:** Enter the tokens/keys of your DNS provider in the `.env` file.
-- **Synology Credentials:** Adjust the hostname, port, and login credentials (dedicated account for this container/script) of your NAS in the `.env` file.
+- **DNS API Credentials:** Enter the tokens/keys of your DNS provider in the `.env` file - there are more providers possible.
+- **Synology Credentials:** Adjust the hostname, port, and login credentials (dedicated account for this container/script - needs admin privileges) of your NAS in the `.env` file.
 - **Volume Paths:** Ensure the path `/volume2/docker/acme/config` in the `docker-compose.yml` matches your actual folder structure so certificates survive container restarts.
-- **Initial Setup:** Run the `acme.sh` commands provided in the `.env` file *once* inside the container's shell to kick off the automated process.
+
+## Initial Setup
+
+Once your configuration is ready and the container is running, you need to execute the following commands *once* inside the container's shell to kick off the automated process.
+
+Access the container shell first (e.g., via `docker exec -it acme-sh sh`), then follow these steps:
+### 1. Register Account
+Register your email address with Let's Encrypt to receive expiration notices.
+```shell
+acme.sh --register-account -m mail@example.com --home /acme.sh
+```
+
+### 2. Issue Certificate
+Choose your DNS provider from the tabs below to issue the certificate. Make sure you use the correct `--dns` flag for your provider.
+
+::: code-group
+
+```sh [Cloudflare]
+acme.sh --issue --dns dns_cf -d syn.example.com -d '*.syn.example.com' --home /acme.sh
+```
+
+```sh [Hetzner]
+acme.sh --issue --dns dns_hetzner -d syn.example.com -d '*.syn.example.com' --home /acme.sh
+```
+
+```sh [Netcup]
+acme.sh --issue --dns dns_netcup -d syn.example.com -d '*.syn.example.com' --home /acme.sh
+```
+:::
+
+### 3. Deploy to Synology
+This step configures the deployment hook so `acme.sh` knows how to push the certificate to your NAS - in this case for the synology provicer.
+
+```sh
+acme.sh --deploy --insecure -d syn.example.com --deploy-hook synology_dsm --home /acme.sh
+```
+
+### 4. Install Certificate
+Finally, install the certificate into the Synology DSM system.
+Afterward, it will appear inside the settings and can be used as the default one - even if the Synology Webserver restarts after that, a good restart of the whole NAS preferred.
+
+```sh
+acme.sh --install-cert -d syn.example.com --deploy-hook synology_dsm --home /acme.sh
+```
+
+### 5. (Optional) Disable DNS Rebind Protection
+
+If you are using a **FritzBox** as your router, you might not be able to access your NAS via your new domain (`syn.example.com`) from *inside* your own local network. 
+To fix this, you need to add an exception in your router settings.
+
+::: tip Why is this necessary?
+By default, the FritzBox blocks DNS responses that resolve to private/local IP addresses to prevent DNS rebinding attacks. 
+Since your custom domain points to the local IP of your Synology NAS, you must explicitly tell the router that these specific domains are safe.
+:::
+
+**Configuration Steps:**
+1. Open your router interface (usually `http://fritz.box`).
+2. Navigate to: **Home Network** → **Network** → **Network Settings** → **Advanced Network Settings** (at the bottom).
+3. Find the section **DNS Rebind Protection** (Host name exceptions).
+4. Enter your domains, each on a new line:
+   ```text
+   syn.example.com
+   *.syn.example.com
+   ```
+5. Click **Apply** to save your settings.
+
 
 ## Links
 
@@ -31,3 +96,4 @@ Before using this stack, adjust:
 - Documentation (Synology Guide): [acme.sh Wiki - Synology NAS Guide](https://github.com/acmesh-official/acme.sh/wiki/Synology-NAS-Guide)
 - Docker Image: [neilpang/acme.sh on Docker Hub](https://hub.docker.com/r/neilpang/acme.sh)
 - Challenge Types: [Challenge Types](https://letsencrypt.org/docs/challenge-types/)
+- DNS Rebind Explanation: [GitHub Blog](https://github.blog/security/application-security/dns-rebinding-attacks-explained-the-lookup-is-coming-from-inside-the-house/)

--- a/synology-acme-dns/acme.env
+++ b/synology-acme-dns/acme.env
@@ -35,34 +35,3 @@ SYNO_CREATE=1
 
 # Label/name of the certificate in DSM (customizable)
 SYNO_CERTIFICATE=syn-example-com-wildcard
-
-# ==========================================
-# Setup Container
-# ==========================================
-# 1. Setup container with neilpang/acme.sh:latest Image
-#
-# 2. Edit YAML-Config according to "compose.yml"
-#
-# 3. Start container and use internal shell for following:
-# ==========================================
-# Manual Deployment Commands (run in container shell once)
-# ==========================================
-# 1. Register account:
-#    acme.sh --register-account -m mail@example.com --home /acme.sh
-#
-# 2. Issue certificate (Choose the correct --dns flag for your provider!):
-#    Cloudflare: acme.sh --issue --dns dns_cf -d syn.example.com -d '*.syn.example.com' --home /acme.sh
-#    Hetzner:    acme.sh --issue --dns dns_hetzner -d syn.example.com -d '*.syn.example.com' --home /acme.sh
-#    Netcup:     acme.sh --issue --dns dns_netcup -d syn.example.com -d '*.syn.example.com' --home /acme.sh
-#
-# 3. Deploy to Synology:
-#    acme.sh --deploy --insecure -d syn.example.com --deploy-hook synology_dsm --home /acme.sh
-#
-# 4. Install cert:
-#    acme.sh --install-cert -d syn.example.com --deploy-hook synology_dsm --home /acme.sh
-# ==========================================
-# FritzBox Settings (if used)
-# ==========================================
-# 1. Go to fritz.box > Home Network > Network > Network settings > Advanced Network Settings (bottom) > DNS Rebind Protection
-#
-# 2. Insert your domains e.g. syn.example.com and *.syn.example.com


### PR DESCRIPTION
- moved documentation from env file to vitepress
- described each step for easy reproduction 